### PR TITLE
docs: add per-component READMEs and update root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,45 @@
 # Proxmox Home Lab — Infrastructure as Code
 
+Fully automated homelab built on Proxmox using a three-layer IaC stack: (So far..)
+
+```
+Packer  →  builds the AlmaLinux 9 golden image (VM 9000)
+Terraform  →  clones that image and provisions all VMs
+Ansible  →  configures and hardens everything post-boot
+```
+
+Secrets for all three tools are stored in HashiCorp Vault (vega).
+
+- [`packer/`](packer/) — Golden image build
+- [`terraform/`](terraform/) — VM provisioning
+- [`ansible/`](ansible/) — Post-boot configuration and hardening
+
+---
+
 ## Naming Theme
 
 VMs use a space-themed naming scheme.
 
-| Host Name | VM ID | Role | Network |
-|-----------|-------|------|---------|
-| polaris | 100 | Firewall / router (OPNsense) | All bridges |
-| sirius | 102 | Jumphost (AlmaLinux) | Management |
+## VM Inventory
+
+| Host | VM ID | Role | Network | IP |
+|------|-------|------|---------|----|
+| polaris | 100 | Firewall / router (OPNsense) | All bridges | — |
+| vega | 101 | HashiCorp Vault | Management | 10.0.0.101 |
+| sirius | 102 | Jumphost | Management | 10.0.0.187 |
+| ansible-test-mgmt | 200 | Ansible test target | Management | 10.0.0.50 |
+| ansible-test-prod | 201 | Ansible test target | Prod | 10.10.0.50 |
+| ansible-test-seclab | 202 | Ansible test target | Security Lab | 10.20.0.50 |
+| triangulum-alpha1 | 300 | k3s server (control plane) | Prod | 10.10.0.100 |
+| triangulum-alpha2 | 301 | k3s server (control plane) | Prod | 10.10.0.101 |
+| triangulum-beta1 | 302 | k3s agent (worker) | Prod | 10.10.0.102 |
+| triangulum-beta2 | 303 | k3s agent (worker) | Prod | 10.10.0.103 |
+| triangulum-beta3 | 304 | k3s agent (worker) | Prod | 10.10.0.104 |
+| triangulum-beta4 | 305 | k3s agent (worker) | Prod | 10.10.0.105 |
+| triangulum-db | 306 | PostgreSQL (k3s datastore) | Prod | 10.10.0.106 |
+| triangulum-lb | 307 | Nginx (k3s API load balancer) | Prod | 10.10.0.107 |
+
+VM 9000 is the AlmaLinux 9 golden image template built by Packer.
 
 ## Network Layout
 
@@ -15,17 +47,19 @@ All networking is virtual inside Proxmox using Open vSwitch bridges. OPNsense (p
 
 | Bridge | Network | Subnet | OPNsense Gateway | Policy |
 |--------|---------|--------|-------------------|--------|
-| vmbr0 | LAN | 192.168.1.0/24 | 192.168.1.2 (WAN) | Uplink to home router |
+| vmbr0 | LAN | 192.168.1.0/24 | 192.168.1.2 | Uplink to home router |
 | vmbr1 | Management | 10.0.0.0/24 | 10.0.0.1 | Full access everywhere |
 | vmbr2 | Prod | 10.10.0.0/24 | 10.10.0.1 | Internet only, no cross-network |
 | vmbr3 | Security Lab | 10.20.0.0/24 | 10.20.0.1 | Fully isolated, intra-segment only |
 
-
 ## Prerequisites
 
-1. Terraform installed on your workstation
-2. `direnv` installed (`sudo dnf install direnv`)
-3. Proxmox API token for the `terraform@pve` service account
+- Terraform >= 1.5.0
+- Packer >= 1.9.0
+- Ansible >= 2.15
+- `direnv` (`sudo dnf install direnv`)
+- HashiCorp Vault running at `http://10.0.0.101:8200` (vega)
+- AlmaLinux 9 minimal ISO uploaded to Proxmox storage
 
 ## Setup
 
@@ -36,32 +70,17 @@ echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
-**2. Create `.envrc`** in the repo root (already in `.gitignore` — never commit this):
+**2. The `.envrc`** in the repo root sets `VAULT_ADDR` (already in `.gitignore` — never commit this):
 
 ```bash
-export PROXMOX_VE_ENDPOINT='https://proxmox:8006'
-export PROXMOX_VE_USERNAME='terraform@pve'
-export PROXMOX_VE_API_TOKEN='terraform@pve!terraform=YOUR_SECRET_HERE'
-export PROXMOX_VE_INSECURE=true
+export VAULT_ADDR='http://10.0.0.101:8200'
 ```
 
-**3. Allow it:**
+**3. Allow it and authenticate to Vault:**
 
 ```bash
 direnv allow
+vault login -method=userpass username=astronuat
 ```
 
-direnv will automatically load these vars whenever you `cd` into the project and unload them when you leave.
-
-## Day-to-Day Usage
-
-```bash
-# See what Terraform would change
-terraform plan
-
-# Apply changes
-terraform apply
-
-# See current state
-terraform output
-```
+All other secrets (Proxmox API token, k3s token, database credentials) are read from Vault at runtime by each tool.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,87 @@
+# Ansible
+
+Configures and hardens all VMs after Terraform provisions them. Connects as the `ansible` user (key-only, set up by the Packer golden image).
+
+## Collections
+
+Managed via `requirements.yml`. Install with:
+
+```bash
+ansible-galaxy collection install -r requirements.yml
+```
+
+| Collection | Purpose |
+|-----------|---------|
+| `devsec.hardening` | OS and SSH hardening (CIS-aligned) |
+| `ansible.posix` | firewalld, SELinux, seboolean |
+| `community.general` | SELinux port management (`seport`) |
+| `community.hashi_vault` | Vault KV lookups at playbook runtime |
+
+## Inventory
+
+`inventory/hosts.yml` — all hosts grouped by role and network segment:
+
+| Group | Hosts | Purpose |
+|-------|-------|---------|
+| `management` | sirius, ansible-test-mgmt | Management network |
+| `prod` | ansible-test-prod | Prod network |
+| `seclab` | ansible-test-seclab | Security lab (no internet) |
+| `k3s_server` | triangulum-alpha1, alpha2 | k3s control plane |
+| `k3s_agent` | triangulum-beta1–4 | k3s workers |
+| `k3s_db` | triangulum-db | PostgreSQL datastore |
+| `k3s_lb` | triangulum-lb | Nginx API load balancer |
+
+## Playbooks
+
+| Playbook | Targets | What it does |
+|----------|---------|-------------|
+| `site.yml` | `all` | Applies devsec OS + SSH hardening and the `basehardening` role |
+| `k3s-server.yml` | `k3s_server` | Opens k3s ports, installs k3s server with HA Postgres datastore |
+| `k3s-agent.yml` | `k3s_agent` | Opens flannel/kubelet ports, installs k3s agent pointing at the LB |
+| `k3s-db.yml` | `k3s_db` | Installs and configures PostgreSQL for k3s |
+| `k3s-lb.yml` | `k3s_lb` | Installs Nginx with stream module, configures TCP load balancing for port 6443 |
+
+## Roles
+
+### `basehardening`
+
+Lab-specific hardening that complements devsec. Configured via `group_vars/all.yml`.
+
+- **firewalld** — enforces an allowlist of services (default: SSH only)
+- **dnf-automatic** — enables automatic security updates
+- **OpenSCAP** — installs `openscap-scanner` + `scap-security-guide` and runs a CIS Level 1 scan; report saved to `/var/log/openscap/report.html`
+
+## Secrets
+
+k3s playbooks pull secrets from Vault at runtime using `community.hashi_vault`:
+
+```yaml
+vault_k3s: "{{ lookup('community.hashi_vault.vault_kv2_get', 'k3s', mount_point='secret') }}"
+```
+
+`VAULT_ADDR` must be set (via `.envrc` + `direnv allow` in the repo root).
+
+Expected keys in `secret/k3s`:
+- `k3s_token` — shared cluster token
+- `k3s_datastore_endpoint` — full Postgres connection string
+
+## Usage
+
+```bash
+cd ansible/
+
+# Install collections (first time)
+ansible-galaxy collection install -r requirements.yml
+
+# Harden all hosts
+ansible-playbook playbooks/site.yml
+
+# Stand up the k3s cluster (run in order)
+ansible-playbook playbooks/k3s-db.yml
+ansible-playbook playbooks/k3s-lb.yml
+ansible-playbook playbooks/k3s-server.yml
+ansible-playbook playbooks/k3s-agent.yml
+
+# Target a specific host or group
+ansible-playbook playbooks/site.yml --limit triangulum-alpha1
+```

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,62 @@
+# Packer
+
+Builds the AlmaLinux 9 golden image (VM 9000) on Proxmox. All Terraform-managed VMs are full clones of this template, with the exception of the jumphost (sirius), which usees the DVD GUI version of AlmaLinux 10 instead of the minimal version used here.
+
+## What it builds
+
+A hardened AlmaLinux 9 minimal install with:
+- System fully updated
+- Base tooling (`vim`, `curl`, `git`, `tmux`, `jq`, etc.)
+- `qemu-guest-agent` and `cloud-init` enabled
+- `ansible` user with sudo and your SSH public key
+- SSH hardened (no root login, no passwords, key-only)
+- `firewalld` enabled (SSH only)
+- SELinux enforcing
+- Machine-specific identifiers scrubbed (machine-id, hostname, SSH host keys) so each clone boots fresh
+
+## Secrets
+
+Packer reads Proxmox credentials and the SSH public key path from Vault using the native `vault()` function:
+
+```hcl
+locals {
+  proxmox_url         = vault("secret/data/packer", "pkr_var_proxmox_url")
+  proxmox_username    = vault("secret/data/packer", "pkr_var_proxmox_username")
+  proxmox_token       = vault("secret/data/packer", "pkr_var_proxmox_token")
+  ssh_public_key_path = vault("secret/data/packer", "pkr_var_ssh_public_key_path")
+}
+```
+
+`VAULT_ADDR` must be set (via `.envrc` + `direnv allow` in the repo root) and you must be authenticated before running a build.
+
+## Prerequisites
+
+- AlmaLinux 9 minimal ISO uploaded to Proxmox (`local:iso/AlmaLinux-9-latest-x86_64-minimal.iso`)
+- Vault authenticated (`vault login`)
+
+## Usage
+
+```bash
+cd packer/alma-minimal/
+
+# Install the Proxmox plugin (first time)
+packer init .
+
+# Validate config
+packer validate .
+
+# Build and register the template
+packer build .
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `almalinux-golden.pkr.hcl` | Main Packer config — VM spec, boot command, build steps |
+| `http/ks.cfg` | Kickstart file served over HTTP during install |
+| `scripts/provision.sh` | Post-install provisioning script run by Packer over SSH |
+
+## Notes
+
+- `cpu_type = "host"` is required. Omitting it causes an immediate kernel panic on boot. This took way too long to figure out..

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,53 @@
+# Terraform
+
+Provisions all VMs on Proxmox. Uses the `bpg/proxmox` provider and reads credentials from HashiCorp Vault via the `hashicorp/vault` provider.
+
+## Secrets
+
+Terraform reads Proxmox credentials from Vault at plan/apply time — no `.envrc` variables needed beyond `VAULT_ADDR`:
+
+```hcl
+data "vault_kv_secret_v2" "proxmox" {
+  mount = "secret"
+  name  = "terraform"
+}
+```
+
+Expected keys in `secret/terraform`:
+- `proxmox_ve_endpoint`
+- `proxmox_ve_username`
+- `proxmox_ve_api_token`
+- `proxmox_ve_insecure`
+
+## Files
+
+| File | What it manages |
+|------|-----------------|
+| `main.tf` | Provider config (Proxmox + Vault) |
+| `polaris.tf` | VM 100 — OPNsense firewall/router |
+| `sirius.tf` | VM 102 — Jumphost |
+| `vega.tf` | VM 101 — HashiCorp Vault server |
+| `ansible-test-vms.tf` | VMs 200–202 — one test target per network segment |
+| `k3s-cluster.tf` | VMs 300–305 — Triangulum k3s cluster (2 servers, 4 agents) |
+| `k3s-db.tf` | VM 306 — PostgreSQL datastore for k3s |
+| `k3s-lb.tf` | VM 307 — Nginx load balancer for the k3s API |
+
+All VMs except polaris and sirius are full clones of the AlmaLinux 9 golden image (VM 9000). Cloud-init is used for network and user configuration at first boot.
+
+## Usage
+
+```bash
+cd terraform/
+
+# Authenticate to Vault first (reads VAULT_ADDR from .envrc)
+vault login -method=userpass username=astronuat
+
+# Preview changes
+terraform plan
+
+# Apply
+terraform apply
+
+# Show current outputs
+terraform output
+```


### PR DESCRIPTION
Closes #12

## Summary

Root README updated to reflect current state of the lab. New per-component READMEs added for Terraform, Ansible, and Packer so each directory is self-contained and navigable.

## What changed

- **Root README**: full VM inventory (all 14 hosts) *as this grows, I'll probs stop doing this, or figure out a better way to inventory, this seems like overkill*, updated network table, three-layer architecture overview (Packer → Terraform → Ansible), and Vault-based setup instructions replacing the old `.envrc` credential block
- **`terraform/README.md`**: Vault secret integration, file-by-file breakdown of all `.tf` resources, and usage commands
- **`ansible/README.md`**: collections table, inventory group reference, playbook reference table, `basehardening` role summary, Vault lookup details, and ordered k3s cluster bring-up commands
- **`packer/README.md`**: golden image contents, Vault secret setup, prerequisites, file reference, and UEFI/OVMF build notes
