### PR TITLE
Adding dns stuff and using fqdns instead of IPs for ansible inventory

### DIFF
--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -4,43 +4,40 @@ all:
     management:
       hosts:
         sirius:
-          ansible_host: 10.0.0.187
+          ansible_host: sirius.home.lab
         ansible-test-mgmt:
-          ansible_host: 10.0.0.50
+          ansible_host: ansible-test-mgmt.home.lab
     prod:
       hosts:
         ansible-test-prod:
-          ansible_host: 10.10.0.50
-    seclab: #NOTE: these won't reach the internet
-      hosts: 
+          ansible_host: ansible-test-prod.home.lab
+    seclab: # NOTE: these won't reach the internet
+      hosts:
         ansible-test-seclab:
-          ansible_host: 10.20.0.50
-
+          ansible_host: ansible-test-seclab.home.lab
     k3s_cluster:
       children:
         k3s_server:
           hosts:
             triangulum-alpha1:
-              ansible_host: 10.10.0.100
+              ansible_host: triangulum-alpha1.home.lab
             triangulum-alpha2:
-              ansible_host: 10.10.0.101
+              ansible_host: triangulum-alpha2.home.lab
         k3s_agent:
           hosts:
             triangulum-beta1:
-              ansible_host: 10.10.0.102
+              ansible_host: triangulum-beta1.home.lab
             triangulum-beta2:
-              ansible_host: 10.10.0.103
+              ansible_host: triangulum-beta2.home.lab
             triangulum-beta3:
-              ansible_host: 10.10.0.104
+              ansible_host: triangulum-beta3.home.lab
             triangulum-beta4:
-              ansible_host: 10.10.0.105
-
+              ansible_host: triangulum-beta4.home.lab
     k3s_db:
       hosts:
         triangulum-db:
-          ansible_host: 10.10.0.106
-
+          ansible_host: triangulum-db.home.lab
     k3s_lb:
       hosts:
         triangulum-lb:
-          ansible_host: 10.10.0.107
+          ansible_host: triangulum-lb.home.lab

--- a/terraform/ansible-test-vms.tf
+++ b/terraform/ansible-test-vms.tf
@@ -74,6 +74,7 @@ resource "proxmox_virtual_environment_vm" "ansible_test" {
   initialization {
     dns {
       servers = [each.value.gateway]
+      domain  = "home.lab"
     }
     ip_config {
       ipv4 {

--- a/terraform/k3s-cluster.tf
+++ b/terraform/k3s-cluster.tf
@@ -101,7 +101,8 @@ resource "proxmox_virtual_environment_vm" "k3s" {
 
   initialization {
     dns {
-      servers = ["10.10.0.1"]
+      servers = [each.value.gateway]
+      domain  = "home.lab"
     }
     ip_config {
       ipv4 {

--- a/terraform/k3s-db.tf
+++ b/terraform/k3s-db.tf
@@ -46,7 +46,8 @@ resource "proxmox_virtual_environment_vm" "k3s_db" {
 
   initialization {
     dns {
-      servers = ["10.10.0.1"]
+      servers = [each.value.gateway]
+      domain  = "home.lab"
     }
     ip_config {
       ipv4 {

--- a/terraform/k3s-lb.tf
+++ b/terraform/k3s-lb.tf
@@ -50,7 +50,8 @@ resource "proxmox_virtual_environment_vm" "k3s_lb" {
 
   initialization {
     dns {
-      servers = ["10.10.0.1"]
+      servers = [each.value.gateway]
+      domain  = "home.lab"
     }
     ip_config {
       ipv4 {

--- a/terraform/vega.tf
+++ b/terraform/vega.tf
@@ -59,7 +59,8 @@ resource "proxmox_virtual_environment_vm" "vega" {
 
   initialization {
     dns {
-      servers = ["10.0.0.1"]
+      servers = [each.value.gateway]
+      domain  = "home.lab"
     }
     ip_config {
       ipv4 {


### PR DESCRIPTION
# Centralized DNS — Unbound Host Overrides

Closes #17 

## Summary

All lab hosts now resolvable by name across all network segments via OPNsense Unbound DNS with the `home.lab` domain.

## What changed

- Unbound host overrides added for all VMs in OPNsense
- Kea DHCPv4 configured to distribute `home.lab` as search domain
- Ansible inventory updated from IPs to FQDNs

## Hosts registered

| Host | IP |
|---|---|
| sirius.home.lab | 10.0.0.187 |
| polaris.home.lab | 10.0.0.1 |
| ansible-test-mgmt.home.lab | 10.0.0.50 |
| triangulum-alpha1.home.lab | 10.10.0.100 |
| triangulum-alpha2.home.lab | 10.10.0.101 |
| triangulum-beta1.home.lab | 10.10.0.102 |
| triangulum-beta2.home.lab | 10.10.0.103 |
| triangulum-beta3.home.lab | 10.10.0.104 |
| triangulum-beta4.home.lab | 10.10.0.105 |
| triangulum-db.home.lab | 10.10.0.106 |
| triangulum-lb.home.lab | 10.10.0.107 |
| ansible-test-prod.home.lab | 10.10.0.50 |
| ansible-test-seclab.home.lab | 10.20.0.50 |

## Validation

```bash
dig sirius.home.lab @10.0.0.1          # resolves
dig triangulum-alpha1.home.lab @10.0.0.1  # resolves
ssh triangulum-db                       # short name works
ansible all -m ping                     # all hosts SUCCESS via FQDN
```
