### PR TITLE
Enhancement/23 kickstart

### DIFF
--- a/packer/alma-minimal/alma-minimal.pkr.hcl
+++ b/packer/alma-minimal/alma-minimal.pkr.hcl
@@ -1,11 +1,32 @@
-variable "proxmox_password" {
-  type    = string
-  default = var.TF_VAR_proxmox_api_token
+packer {
+  required_plugins {
+    proxmox = {
+      version = ">= 1.2.2"
+      source = "github.com/hashicorp/proxmox"
+    }
+  }
 }
+
+# VARIABLES
+variable "proxmox_node" {
+  type = string
+  default = "lab"
+}
+
+variable "vm_id" {
+  type = number
+  default = 9000
+}
+
+variable "storage_pool" {
+  type = string
+  default = "local-lvm"
+}
+
 
 variable "proxmox_username" {
   type    = string
-  default = "root@pve"
+  default = "terraform@pve!packer-token"
 }
 
 variable "proxmox_url" {
@@ -13,28 +34,78 @@ variable "proxmox_url" {
   default = "https://192.168.1.180:8006/api2/json/"
 }
 
-source "proxmox-clone" "alma" {
-  clone_vm                 = "alma-minimal"
-  cores                    = 1
-  insecure_skip_tls_verify = true
+variable "proxmox_api_token" {
+  type = string
+}
+
+# SOURCE
+source "proxmox-iso" "alma-minimal-golden" {
+  proxmox_url          = "${var.proxmox_url}"
+  username             = "${var.proxmox_username}"
+  token             = "${var.proxmox_api_token}"
+  node                 = "${var.proxmox_node}"
+
+
+  vm_id = "${var.vm_id}"
+  vm_name = "almalinux9-golden"
+  machine = "q35"
+  bios = "ovmf"
+
+  efi_config {
+    efi_storage_pool = "${var.storage_pool}"
+    pre_enrolled_keys = false
+  }
+
+  template_name        = "alma-scaffolding"
+  template_description = "AlmaLinux 9 Golden Image"
+  os                   = "l26"
+  qemu_agent = true
+
+  cores                    = 2
+  sockets              = 1
   memory                   = 2048
+  insecure_skip_tls_verify = true
+  cpu_type = "host"
+
+  scsi_controller = "virtio-scsi-single"
+
+  disks {
+    type = "scsi"
+    disk_size = "20G"
+    storage_pool = "${var.storage_pool}"
+  }
+
   network_adapters {
-    bridge = "vmbr0"
+    bridge = "vmbr1"
     model  = "virtio"
   }
-  node                 = "pve"
-  os                   = "l26"
-  password             = "${var.proxmox_password}"
-  pool                 = "api-users"
-  proxmox_url          = "${var.proxmox_url}"
-  sockets              = 1
-  ssh_username         = "astronuat"
-  template_description = "image made from cloud-init image"
-  template_name        = "alma-scaffolding"
-  username             = "${var.proxmox_username}"
+
+  boot_iso {
+    iso_file                 = "local:iso/AlmaLinux-9-latest-x86_64-minimal.iso"
+    unmount = true
+    iso_checksum = "none"
+  }
+
+  ssh_username         = "root"
+  ssh_password = "packer"
+  ssh_timeout = "20m"
+
+  http_directory = "./http"
+
+  boot_command = [
+    "<wait><up><wait3>",
+    "e<wait2>",
+    "<down><down><end><wait>",
+    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg",
+    "<leftCtrlOn>x<leftCtrlOff>"
+  ]
+  boot_wait = "20s"
+
+  cloud_init = true
+  cloud_init_storage_pool = "${var.storage_pool}"
 }
 
 build {
-  sources = ["source.proxmox-clone.debian"]
+  sources = ["source.proxmox-iso.alma-minimal-golden"]
 }
 

--- a/packer/alma-minimal/http/ks.cfg
+++ b/packer/alma-minimal/http/ks.cfg
@@ -42,6 +42,7 @@ services --enabled=sshd
 dnf install -y qemu-guest-agent
 systemctl enable sshd
 systemctl enable qemu-guest-agent
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/99-packer.conf
 %end
 
 reboot

--- a/packer/alma-minimal/ks.cfg
+++ b/packer/alma-minimal/ks.cfg
@@ -1,0 +1,47 @@
+# AlmaLinux Kickstart
+# Ref: https://wiki.almalinux.org/documentation/kickstart-guide.html
+text
+skipx
+eula --agreed
+firstboot --disable
+
+# Localization
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+timesource --ntp-server=pool.ntp.org
+
+# Network — DHCP during build (on vmbr0)
+network --bootproto=dhcp --device=link --activate --onboot=yes
+
+rootpw --plaintext packer
+
+# Partitioning
+clearpart --all --initlabel
+autopart --type=lvm
+
+# Bootloader
+bootloader --append="crashkernel=no"
+
+# SELinux
+selinux --enforcing
+
+# Firewall — allow SSH
+firewall --enabled --ssh
+
+# Services
+services --enabled=sshd
+
+# Minimal package set — additional packages installed by provisioning script
+%packages --ignoremissing
+@^minimal-environment
+%end
+
+# Post-install
+%post --log=/root/ks-post.log
+dnf install -y qemu-guest-agent
+systemctl enable sshd
+systemctl enable qemu-guest-agent
+%end
+
+reboot

--- a/terraform/modules/alma-minimal/main.tf
+++ b/terraform/modules/alma-minimal/main.tf
@@ -20,14 +20,14 @@ resource "proxmox_virtual_environment_vm" "alma-minimal" {
   tags          = ["terraform"]
 
   cpu {
-    cores   = 2
+    cores   = each.value.cores
     sockets = 1
     type    = "host"
   }
 
   cdrom {
     #file_id = "local:iso/AlmaLinux-10.1-x86_64-dvd.iso"
-    file_id = each.value.file_id
+    file_id = "none"
 
   }
 
@@ -36,7 +36,7 @@ resource "proxmox_virtual_environment_vm" "alma-minimal" {
   }
 
   memory {
-    dedicated = 3072
+    dedicated = each.value.mem
   }
 
 

--- a/terraform/modules/alma-minimal/variables.tf
+++ b/terraform/modules/alma-minimal/variables.tf
@@ -5,6 +5,8 @@ variable "almalinux_vms" {
     bridge  = string
     address = string
     gateway = string
+    cores   = optional(number, 2)
+    mem     = optional(number, 3072)
   }))
 
   default = {
@@ -13,7 +15,6 @@ variable "almalinux_vms" {
       bridge  = "vmbr1"
       address = "10.0.0.3/24"
       gateway = "10.0.0.1"
-      file_id = "local:iso/AlmaLinux-9-latest-x86_64-minimal.iso"
     }
 
     // Test machines
@@ -34,6 +35,14 @@ variable "almalinux_vms" {
       bridge  = "vmbr2"
       address = "10.20.0.7/24"
       gateway = "10.20.0.1"
+    }
+    "lfs-build" = {
+      vm_id   = 777
+      bridge  = "vmbr1"
+      address = "10.0.0.99/24"
+      gateway = "10.0.0.1"
+      cores   = 4
+      mem     = 8192
     }
   }
 }


### PR DESCRIPTION
Closes #23 
## Summary
This completed requirements for kickstart and packer for building an alma9 minimal machine. 

## What changed
- Build packer and kickstart provisioning templates/configs
 
## Validation

On the build host (`andromeda`) run `packer build .`

## Future improvements

Packer builds for other images I'd use