### PR TITLE
feat: Added pihole via FCOS using terraform/pxebooting

### DIFF
--- a/ignition/pihole.bu
+++ b/ignition/pihole.bu
@@ -1,0 +1,60 @@
+
+variant: fcos
+version: 1.5.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIER93Zz4hF16OEjzZstU1JtYfTHDPAgq8SUG1VsjJXiw blnorris777@gmail.com
+
+storage:
+  files:
+    - path: /etc/NetworkManager/system-connections/static.nmconnection
+      mode: 0600
+      contents:
+        inline: |
+          [connection]
+          id=static
+          type=ethernet
+
+          [ipv4]
+          method=manual
+          addresses=10.0.0.53/24
+          gateway=10.0.0.1
+          dns=1.1.1.1;8.8.8.8
+
+          [ipv6]
+          method=disabled
+
+    - path: /etc/systemd/resolved.conf.d/no-stub.conf
+      contents:
+        inline: |
+          [Resolve]
+          DNSStubListener=no
+
+    - path: /etc/containers/systemd/pihole.container
+      contents:
+        inline: |
+          [Unit]
+          Description=PiHole DNS
+          After=network-online.target
+
+          [Container]
+          Image=docker.io/pihole/pihole:latest
+          PublishPort=53:53/tcp
+          PublishPort=53:53/udp
+          PublishPort=80:80/tcp
+          Environment=TZ=America/New_York
+          Environment=FTLCONF_webserver_api_password=changeme
+          Volume=pihole_data:/etc/pihole:Z
+          Volume=pihole_dnsmasq:/etc/dnsmasq.d:Z
+          AddCapability=NET_ADMIN
+
+          [Service]
+          Restart=always
+
+          [Install]
+          WantedBy=multi-user.target
+
+systemd:
+  units:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,3 +29,7 @@ module "alma-minimal" {
 module "vega" {
   source = "./modules/vega/"
 }
+
+module "fcos-pihole" {
+  source = "./modules/fcos-pihole/"
+}

--- a/terraform/modules/fcos-pihole/main.tf
+++ b/terraform/modules/fcos-pihole/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_version = ">= 1.14.7"
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "0.98.1"
+    }
+  }
+}
+
+resource "proxmox_virtual_environment_vm" "pihole" {
+  name          = "pihole"
+  vm_id         = 401
+  node_name     = "lab"
+  scsi_hardware = "virtio-scsi-single"
+  machine       = "q35"
+  bios          = "ovmf"
+  description   = "PiHole DNS running on FCOS"
+  tags          = ["terraform", "fcos", "pihole"]
+
+  #boot_order = ["net0", "scsi0"]
+
+  cpu {
+    cores   = 2
+    sockets = 1
+    type    = "host"
+  }
+
+  memory {
+    dedicated = 4096
+  }
+
+  disk {
+    datastore_id = "local-lvm"
+    interface    = "scsi0"
+    iothread     = true
+    size         = 20
+  }
+
+  efi_disk {
+    datastore_id = "local-lvm"
+    type         = "4m"
+  }
+
+  network_device {
+    bridge = "vmbr1"
+  }
+
+  operating_system {
+    type = "l26"
+  }
+}


### PR DESCRIPTION
Closes #31 
## Summary
This added the terraform files for my pihole and all the pxeboot stuff for booting FCOS along with the butane file used for igntion

## What changed
Added terraform, butane, added pxe boot files

## Validation
Go to http://pihole.home.lab/admin and login

## Future improvements
N/A