### PR TITLE
Enhancement/38 tls reverse proxy

### DIFF
--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -15,6 +15,7 @@ all:
         hubble:
         alpha-cen:
         proxima-cen:
+        vega:
 
     test:
       hosts:

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,8 +1,9 @@
 ---
-- name: Apply base hardening to all hosts and add DNS
+- name: Apply base hardening to all hosts, add DNS, and add step-ca
   hosts: all
   become: true
 
   roles:
     - role: basehardening
     - role: pihole_dns
+    - role: step_ca

--- a/ansible/roles/step_ca/tasks/main.yml
+++ b/ansible/roles/step_ca/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Add Smallstep repository
+  ansible.builtin.copy:
+    dest: /etc/yum.repos.d/smallstep.repo
+    mode: "0644"
+    content: |
+      [smallstep]
+      name=Smallstep
+      baseurl=https://packages.smallstep.com/stable/fedora/
+      enabled=1
+      repo_gpgcheck=0
+      gpgcheck=1
+      gpgkey=https://packages.smallstep.com/keys/smallstep-0x889B19391F774443.gpg
+
+- name: Install step-cli and step-ca
+  ansible.builtin.dnf:
+    name:
+      - step-cli
+      - step-ca
+    state: present
+    update_cache: true


### PR DESCRIPTION
Closes #38 
## Summary
  - Deploys Caddy as a Podman quadlet on hubble, reverse proxying https://ollama.home.lab to 127.0.0.1:11434
  - Stands up step-ca on sirius as a homelab internal CA with ACME provisioner
  - Caddy obtains and auto-renews TLS certs from step-ca via ACME
  - Adds ollama.home.lab DNS record pointing to hubble

##  Acceptance criteria verified
  - curl https://ollama.home.lab/api/tags returns model list from peer VM 
  - TLS handshake uses internal CA chain with no cert warnings on trusted clients 
  - Port 11434 filtered externally (verified with nmap from sirius) 
  - Both Caddy and Ollama survive reboot 
