### PR TITLE
Enhancement/50 argocd

### DIFF
--- a/ansible/playbooks/k8s-argocd.yml
+++ b/ansible/playbooks/k8s-argocd.yml
@@ -1,0 +1,9 @@
+---
+- name: Bootstrap ArgoCD
+  hosts: control
+  become: true
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+
+  roles:
+    - role: k8s-argocd

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -6,3 +6,5 @@ collections:
     version: ">=8.0.0"
   - name: containers.podman
     version: ">=1.20.1"
+  - name: kubernetes.core
+    version: ">=3.0.0"

--- a/ansible/roles/k8s-argocd/README.md
+++ b/ansible/roles/k8s-argocd/README.md
@@ -1,0 +1,12 @@
+# k8s-argocd
+
+Bootstraps ArgoCD
+
+## What it does
+
+
+## Usage
+
+```bash
+ansible-playbook playbooks/k8s-argocd.yml
+```

--- a/ansible/roles/k8s-argocd/tasks/main.yml
+++ b/ansible/roles/k8s-argocd/tasks/main.yml
@@ -1,2 +1,29 @@
 ---
-# Argocd tasks file
+- name: Add Helm repo and install chart
+  kubernetes.core.helm:
+    name: argocd
+    chart_ref: argo-cd
+    chart_version: "{{ argocd_chart_version }}"
+    repo_url: https://argoproj.github.io/argo-helm
+    release_namespace: "{{ argocd_namespace }}"
+    create_namespace: true
+    wait: true
+    values:
+      configs:
+        params:
+          server.insecure: true
+
+- name: Wait for argocd-server
+  kubernetes.core.k8s_info:
+    kind: Deployment
+    name: argocd-server
+    namespace: "{{ argocd_namespace }}"
+    wait: true
+    wait_condition:
+      type: Available
+      status: "True"
+
+- name: Apply root app-of-apps
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', root_app_manifest) | from_yaml }}"

--- a/ansible/roles/k8s-argocd/tasks/main.yml
+++ b/ansible/roles/k8s-argocd/tasks/main.yml
@@ -1,29 +1,44 @@
 ---
-- name: Add Helm repo and install chart
-  kubernetes.core.helm:
-    name: argocd
-    chart_ref: argo-cd
-    chart_version: "{{ argocd_chart_version }}"
-    repo_url: https://argoproj.github.io/argo-helm
-    release_namespace: "{{ argocd_namespace }}"
-    create_namespace: true
-    wait: true
-    values:
-      configs:
-        params:
-          server.insecure: true
+- name: Create venv for k8s python deps
+  ansible.builtin.command:
+    cmd: python3 -m venv /opt/ansible-venv
+    creates: /opt/ansible-venv
 
-- name: Wait for argocd-server
-  kubernetes.core.k8s_info:
-    kind: Deployment
-    name: argocd-server
-    namespace: "{{ argocd_namespace }}"
-    wait: true
-    wait_condition:
-      type: Available
-      status: "True"
+- name: Install python deps into venv
+  ansible.builtin.command:
+    cmd: /opt/ansible-venv/bin/pip install kubernetes PyYAML
+  register: pip_install
+  changed_when: "'Successfully installed' in pip_install.stdout"
 
-- name: Apply root app-of-apps
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ lookup('file', root_app_manifest) | from_yaml }}"
+- name: ArgoCD Install + bootstrap
+  vars:
+    ansible_python_interpreter: /opt/ansible-venv/bin/python
+  block:
+    - name: Add Helm repo and install chart
+      kubernetes.core.helm:
+        name: argocd
+        chart_ref: argo-cd
+        chart_version: "{{ argocd_chart_version }}"
+        chart_repo_url: https://argoproj.github.io/argo-helm
+        release_namespace: "{{ argocd_namespace }}"
+        create_namespace: true
+        wait: true
+        values:
+          configs:
+            params:
+              server.insecure: true
+
+    - name: Wait for argocd-server
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        name: argocd-server
+        namespace: "{{ argocd_namespace }}"
+        wait: true
+        wait_condition:
+          type: Available
+          status: "True"
+
+    - name: Apply root app-of-apps
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('file', root_app_manifest) | from_yaml }}"

--- a/ansible/roles/k8s-argocd/tasks/main.yml
+++ b/ansible/roles/k8s-argocd/tasks/main.yml
@@ -27,6 +27,9 @@
           configs:
             params:
               server.insecure: true
+          server:
+            service:
+              type: LoadBalancer
 
     - name: Wait for argocd-server
       kubernetes.core.k8s_info:

--- a/ansible/roles/k8s-argocd/tasks/main.yml
+++ b/ansible/roles/k8s-argocd/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# Argocd tasks file

--- a/ansible/roles/k8s-argocd/vars/main.yml
+++ b/ansible/roles/k8s-argocd/vars/main.yml
@@ -1,0 +1,4 @@
+---
+argocd_chart_version: "9.6.0"
+argocd_namespace: "argocd"
+root_app_manifest: "{{ playbook_dir }}/../../gitops/bootstrap/root-app.yaml"

--- a/ansible/roles/k8s-control-prep/handlers/main.yml
+++ b/ansible/roles/k8s-control-prep/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart cilium
+  ansible.builtin.command: kubectl -n kube-system rollout restart ds/cilium

--- a/ansible/roles/k8s-control-prep/tasks/main.yml
+++ b/ansible/roles/k8s-control-prep/tasks/main.yml
@@ -85,6 +85,12 @@
       k8sServicePort: 6443
       ipam:
         mode: kubernetes
+      l2announcements:
+        enabled: true
+      k8sClientRateLimit:
+        qps: 10
+        burst: 20
+    notify: Restart cilium
 
 - name: Install/upgrade Cilium
   ansible.builtin.command:

--- a/gitops/apps/cilium-l2-policy.yaml
+++ b/gitops/apps/cilium-l2-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: lan-l2
+spec:
+  loadBalancerIPs: true
+  interfaces:
+    - ^ens18$
+  nodeSelector:
+    matchLabels: {}

--- a/gitops/apps/cilium-lb-pool.yaml
+++ b/gitops/apps/cilium-lb-pool.yaml
@@ -1,0 +1,8 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: lan-pool
+spec:
+  blocks:
+    - start: "10.0.0.200"
+      stop: "10.0.0.250"

--- a/gitops/bootstrap/root-app.yaml
+++ b/gitops/bootstrap/root-app.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/phdbuilds/home.lab.git
-    targetRevision: master
+    targetRevision: enhancement/50-argocd 
     path: gitops/apps
   destination:
     server: https://kubernetes.default.svc

--- a/gitops/bootstrap/root-app.yaml
+++ b/gitops/bootstrap/root-app.yaml
@@ -8,7 +8,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/phdbuilds/home.lab.git
-    targetRevision: enhancement/50-argocd 
+    targetRevision: master
     path: gitops/apps
   destination:
     server: https://kubernetes.default.svc

--- a/gitops/bootstrap/root-app.yaml
+++ b/gitops/bootstrap/root-app.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/phdbuilds/home.lab.git
+    targetRevision: master
+    path: gitops/apps
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
Closes #50.
## Overview
Bootstrapped ArgoCD

## Changes
### New `k8s-argocd` Ansible role
- Installs ArgoCD via the `argo-cd` Helm chart (`kubernetes.core.helm`).
- Creates a Python venv on the FCOS control node (`/opt/ansible-venv`) for the
  `kubernetes` + `PyYAML` libs the modules require
- `server.insecure: true` so Caddy/ingress can front it later without double-TLS.
- `server.service.type: LoadBalancer` to get a stable LAN IP via Cilium LB-IPAM.
- Applies the root app-of-apps from `gitops/bootstrap/root-app.yaml`.

### GitOps structure
- `gitops/bootstrap/root-app.yaml` — root `Application` pointing at
  `gitops/apps` on `master`
- `gitops/apps/` — now holds the Cilium LB-IPAM pool + L2 policy.

### Cilium LB-IPAM + L2 announcements (`k8s-control-prep`)
- Enables `l2announcements` in the rendered Cilium values + adds
  `k8sClientRateLimit` (recommended with L2).
- Adds a `Restart cilium` handler that rolls `ds/cilium` when the values file
  changes
- `CiliumLoadBalancerIPPool` (`10.0.0.200–10.0.0.250`, outside DHCP) and
  `CiliumL2AnnouncementPolicy` (interface `ens18`) committed under `gitops/apps/`.

## Verification
- `kubectl get applications -n argocd` → `root` is `Synced` / `Healthy`.
- `kubectl get svc -n argocd argocd-server` → `EXTERNAL-IP 10.0.0.200`.
- `curl -sI http://10.0.0.200` → `HTTP/1.1 200 OK`.
- `kubectl -n kube-system get lease | grep l2` → active L2 announcement lease.